### PR TITLE
Abort responses

### DIFF
--- a/scanomatic/ui_server/general.py
+++ b/scanomatic/ui_server/general.py
@@ -5,7 +5,8 @@ from StringIO import StringIO
 import io
 from scipy.misc import imread
 from itertools import chain
-from flask import send_file, request, send_from_directory, jsonify, render_template
+from flask import (
+    send_file, request, send_from_directory, jsonify, render_template)
 from werkzeug.datastructures import FileStorage
 import numpy as np
 import zipfile
@@ -27,6 +28,13 @@ _no_super = re.compile(r"/?\.{2}/")
 _logger = Logger("UI API helpers")
 _ALLOWED_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.tiff'}
 _TOO_LARGE_GRAYSCALE_AREA = 300000
+
+
+def json_abort(status_code, *args, **kwargs):
+
+    response = jsonify(*args, **kwargs)
+    response.status_code = status_code
+    return response
 
 
 def image_is_allowed(ext):

--- a/scanomatic/ui_server/test/test_general.py
+++ b/scanomatic/ui_server/test/test_general.py
@@ -1,0 +1,34 @@
+import pytest
+
+from flask import Flask, request
+
+from scanomatic.ui_server import general
+
+
+@pytest.fixture(scope='module')
+def app():
+
+    _app = Flask("--dummy--")
+    with _app.app_context():
+        yield _app
+
+
+class TestJsonAbort:
+    @pytest.mark.parametrize(
+        "status_code,args,kwargs",
+        [
+            (300, [], {}),
+            (400, [1, 2,], {}),
+            (500, [], {'3': 1, '1': 20}),
+        ]
+    )
+    def test_json_abort(self, app, status_code, args, kwargs):
+
+        with app.test_request_context():
+            assert general.json_abort(
+                status_code, *args, **kwargs).status_code == status_code
+
+    def test_json_abort_raises(self, app):
+        with app.test_request_context():
+            with pytest.raises(TypeError):
+                assert general.json_abort(600, *[42,], **{'20': 21, '21': 20})


### PR DESCRIPTION
This is a partial fix to the problem of how the api gave status-code 200 on gracefully refusing or failing requests. It will now give reasonable status-code for the example end-point. Then all other endpoints need updating once agreed that this is nice way.